### PR TITLE
Perform sanity-check on freshness of data

### DIFF
--- a/src/app/query.ts
+++ b/src/app/query.ts
@@ -20,6 +20,7 @@ export const getCirculatingSupply = async (): Promise<string | null> => {
 
     // No data - return null
     if (!response.data) {
+      console.error(`No data returned from API`);
       returnValue = null;
     }
     // Has data
@@ -30,15 +31,17 @@ export const getCirculatingSupply = async (): Promise<string | null> => {
       const isEthereumTimestampValid = response.data.timestamps.Ethereum * 1000 > eightHoursAgoMilliseconds;
       const isArbitrumTimestampValid = response.data.timestamps.Arbitrum * 1000 > eightHoursAgoMilliseconds;
 
+      console.log(`Arbitrum timestamp: ${response.data.timestamps.Arbitrum}`);
+      console.log(`Ethereum timestamp: ${response.data.timestamps.Ethereum}`);
+
       // If either timestamp is invalid, return null
       if (!isEthereumTimestampValid || !isArbitrumTimestampValid) {
         console.error(`Arbitrum or Ethereum timestamps were out of range`);
-        console.log(`Arbitrum timestamp: ${response.data.timestamps.Arbitrum}`);
-        console.log(`Ethereum timestamp: ${response.data.timestamps.Ethereum}`);
         returnValue = null;
       }
+      // Return the circulating supply
       else {
-        // Return the circulating supply
+        console.log(`Arbitrum and Ethereum timestamps are within range`);
         returnValue = response.data.ohmCirculatingSupply.toString();
       }
     }


### PR DESCRIPTION
This resolves an issue encountered over the weekend: the protocol-metrics subgraph hosted on the Graph Protocol Decentralized Network was returning data from an indexer that was 3 months out of date (the indexer may have been new and was in the process of indexing). This led to an incorrect value being sent to CoinGecko.

The freshness of the per-chain values is now checked, and if outside an 8-hour window, the cached value is returned. This should prevent the issue from re-occurring.