### PR TITLE
build(deps): remediate sigstore vulnerabilities

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,15 +6,18 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   audit:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
+        with:
+          persist-credentials: false
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
+        with:
+          persist-credentials: false
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
@@ -26,7 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
+        with:
+          persist-credentials: false
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This repository provides a thin API layer for serving Olympus OHM circulating-su
 
 - Node.js must use version 22+ because the deployed Cloud Functions runtime is pinned to `nodejs22`.
 - Use `.nvmrc` and `.node-version` files for version alignment.
-- Use pnpm 10.33.0 or newer. The exact package manager version is recorded in `package.json`.
+- Use pnpm 11.13.0 or newer. The exact package manager version is recorded in `package.json`.
 - Shared pnpm policy lives in `pnpm-workspace.yaml`, including `nodeLinker: hoisted` for Pulumi closure compatibility and `preferFrozenLockfile: true` for frozen lockfile installs.
 - Run `pnpm install` before dependency-dependent work.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ When the function's trigger URL is hit, the following are performed:
 ## Requirements
 
 - Node.js 22 or newer. The expected version is recorded in `.nvmrc` and `.node-version`.
-- pnpm 10.33.0 or newer. The exact package manager version is recorded in `package.json`.
+- pnpm 11.13.0 or newer. The exact package manager version is recorded in `package.json`.
 - Pulumi CLI access for deployment tasks.
 - GCP credentials for the target stack when previewing or deploying infrastructure.
 

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "engines": {
     "node": ">=22",
-    "pnpm": ">=10.33.0",
+    "pnpm": ">=11.13.0",
     "npm": "use-pnpm",
     "yarn": "use-pnpm"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.13.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@grpc/grpc-js@<1.8.22': ^1.8.22
   '@grpc/grpc-js@>=1.12.0 <1.12.7': ^1.12.7
   '@protobufjs/utf8@<1.1.1': ^1.1.1
+  '@sigstore/core@<=3.2.0': ^3.2.1
   brace-expansion@<2.0.3: ^2.0.3
   cross-spawn@<7.0.5: ^7.0.5
   diff@>=4.0.0 <4.0.4: ^4.0.4
@@ -29,6 +30,7 @@ overrides:
   protobufjs@<=7.6.2: ^7.6.3
   protobufjs-cli@<1.2.1: ^1.2.1
   protobufjs-cli@<=1.3.2: ^1.3.3
+  sigstore@<=4.1.0: ^4.1.1
   tar@<7.5.11: ^7.5.11
   tar@<=7.5.15: ^7.5.16
   tmp@<0.2.6: ^0.2.6
@@ -591,8 +593,8 @@ packages:
     resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@sigstore/core@3.2.0':
-    resolution: {integrity: sha512-kxHrDQ9YgfrWUSXU0cjsQGv8JykOFZQ9ErNKbFPWzk3Hgpwu8x2hHrQ9IdA8yl+j9RTLTC3sAF3Tdq1IQCP4oA==}
+  '@sigstore/core@3.2.1':
+    resolution: {integrity: sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   '@sigstore/protobuf-specs@0.5.1':
@@ -607,8 +609,8 @@ packages:
     resolution: {integrity: sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@sigstore/verify@3.1.0':
-    resolution: {integrity: sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==}
+  '@sigstore/verify@3.1.1':
+    resolution: {integrity: sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   '@sindresorhus/is@4.6.0':
@@ -1649,8 +1651,8 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  sigstore@4.1.0:
-    resolution: {integrity: sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==}
+  sigstore@4.1.1:
+    resolution: {integrity: sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   smart-buffer@4.2.0:
@@ -2430,7 +2432,7 @@ snapshots:
     dependencies:
       '@sigstore/protobuf-specs': 0.5.1
 
-  '@sigstore/core@3.2.0': {}
+  '@sigstore/core@3.2.1': {}
 
   '@sigstore/protobuf-specs@0.5.1': {}
 
@@ -2438,7 +2440,7 @@ snapshots:
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@sigstore/bundle': 4.0.0
-      '@sigstore/core': 3.2.0
+      '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.1
       make-fetch-happen: 15.0.5
       proc-log: 6.1.0
@@ -2452,10 +2454,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/verify@3.1.0':
+  '@sigstore/verify@3.1.1':
     dependencies:
       '@sigstore/bundle': 4.0.0
-      '@sigstore/core': 3.2.0
+      '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.1
 
   '@sindresorhus/is@4.6.0': {}
@@ -3411,7 +3413,7 @@ snapshots:
       npm-pick-manifest: 11.0.3
       npm-registry-fetch: 19.1.1
       proc-log: 6.1.0
-      sigstore: 4.1.0
+      sigstore: 4.1.1
       ssri: 13.0.1
       tar: 7.5.16
     transitivePeerDependencies:
@@ -3567,14 +3569,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sigstore@4.1.0:
+  sigstore@4.1.1:
     dependencies:
       '@sigstore/bundle': 4.0.0
-      '@sigstore/core': 3.2.0
+      '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.1
       '@sigstore/sign': 4.1.1
       '@sigstore/tuf': 4.0.2
-      '@sigstore/verify': 3.1.0
+      '@sigstore/verify': 3.1.1
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,22 +1,26 @@
+allowBuilds:
+  # Reviewed install-time binary fetch for the TypeScript runtime resolved in the lockfile.
+  esbuild: true
+  # Reviewed postinstall helper required by the patched protobufjs runtime.
+  protobufjs: true
 auditConfig:
-  ignoreCves:
+  ignoreGhsas:
     # Pulumi currently pins the OpenTelemetry 1.x stack; forcing core 2.x breaks `pulumi up`.
-    - CVE-2026-54285
+    - GHSA-8988-4f7v-96qf
 blockExoticSubdeps: true
 engineStrict: true
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
+  - "@sigstore/core@3.2.1"
+  - "@sigstore/verify@3.1.1"
   - "@olympusdao/treasury-subgraph-client@3.0.0"
+  - "sigstore@4.1.1"
 nodeLinker: hoisted
-onlyBuiltDependencies:
-  # Reviewed install-time binary fetch for the pinned TypeScript runtime.
-  - "esbuild@0.28.1"
-  # Reviewed postinstall helper required by the patched protobufjs runtime.
-  - "protobufjs@7.6.3"
 overrides:
   "@grpc/grpc-js@<1.8.22": "^1.8.22"
   "@grpc/grpc-js@>=1.12.0 <1.12.7": "^1.12.7"
   "@protobufjs/utf8@<1.1.1": "^1.1.1"
+  "@sigstore/core@<=3.2.0": "^3.2.1"
   "brace-expansion@<2.0.3": "^2.0.3"
   "cross-spawn@<7.0.5": "^7.0.5"
   "diff@>=4.0.0 <4.0.4": "^4.0.4"
@@ -38,6 +42,7 @@ overrides:
   "protobufjs@<=7.6.2": "^7.6.3"
   "protobufjs-cli@<1.2.1": "^1.2.1"
   "protobufjs-cli@<=1.3.2": "^1.3.3"
+  "sigstore@<=4.1.0": "^4.1.1"
   "tar@<7.5.11": "^7.5.11"
   "tar@<=7.5.15": "^7.5.16"
   "tmp@<0.2.6": "^0.2.6"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,8 @@
 allowBuilds:
   # Reviewed install-time binary fetch for the TypeScript runtime resolved in the lockfile.
-  esbuild: true
+  "esbuild@0.28.1": true
   # Reviewed postinstall helper required by the patched protobufjs runtime.
-  protobufjs: true
+  "protobufjs@7.6.3": true
 auditConfig:
   ignoreGhsas:
     # Pulumi currently pins the OpenTelemetry 1.x stack; forcing core 2.x breaks `pulumi up`.


### PR DESCRIPTION
## Summary

Pulumi's transitive package tooling now resolves patched Sigstore releases, clearing the high and moderate advisories without broad dependency churn. The repository also uses pnpm 11.13.0 policy semantics so reviewed build scripts and the existing OpenTelemetry audit exception remain effective, while CI checkout credentials and write permissions are narrowed.

## Validation

- Clean `pnpm install --no-frozen-lockfile`
- Clean `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level moderate` (passes with the existing OpenTelemetry advisory ignored)
- `pnpm run lint:check`
- `pnpm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup requirements to require pnpm **11.13.0 or newer** (and aligned package manager constraints in project config).
* **Security**
  * Tightened CI workflow permissions to the minimum needed and prevented GitHub credentials from persisting across workflow steps.
  * Refined automated dependency auditing rules and release timing controls.
* **Maintenance**
  * Updated workspace build and override/audit configurations to improve installation/build consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->