### PR TITLE
fix(deps): remediate July pnpm advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,7 @@ overrides:
   '@grpc/grpc-js@>=1.12.0 <1.12.7': ^1.12.7
   '@protobufjs/utf8@<1.1.1': ^1.1.1
   '@sigstore/core@<=3.2.0': ^3.2.1
-  brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
-  brace-expansion@>=3.0.0 <5.0.7: ^5.0.7
+  brace-expansion@>=2.0.0 <5.0.8: ^5.0.8
   cross-spawn@<7.0.5: ^7.0.5
   diff@>=4.0.0 <4.0.4: ^4.0.4
   glob@<10.5.0: ^10.5.0
@@ -30,7 +29,7 @@ overrides:
   protobufjs-cli@<1.2.1: ^1.2.1
   protobufjs-cli@<=1.3.2: ^1.3.3
   sigstore@<=4.1.0: ^4.1.1
-  tar@>=7.0.0 <7.5.19: ^7.5.19
+  tar@>=7.0.0 <7.5.21: ^7.5.21
   tmp@<0.2.6: ^0.2.6
   underscore@<1.13.8: ^1.13.8
 
@@ -738,9 +737,6 @@ packages:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -758,12 +754,9 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -1586,8 +1579,8 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  tar@7.5.20:
-    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
+  tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
@@ -2425,8 +2418,6 @@ snapshots:
 
   arrify@2.0.1: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -2443,11 +2434,7 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2953,11 +2940,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
@@ -3022,7 +3009,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.6.3
-      tar: 7.5.20
+      tar: 7.5.21
       tinyglobby: 0.2.15
       which: 6.0.1
     transitivePeerDependencies:
@@ -3145,7 +3132,7 @@ snapshots:
       proc-log: 6.1.0
       sigstore: 4.1.1
       ssri: 13.0.1
-      tar: 7.5.20
+      tar: 7.5.21
     transitivePeerDependencies:
       - supports-color
 
@@ -3364,7 +3351,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  tar@7.5.20:
+  tar@7.5.21:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ minimumReleaseAgeExclude:
   - "@sigstore/core@3.2.1"
   - "@sigstore/verify@3.1.1"
   - "@olympusdao/treasury-subgraph-client@3.0.0"
+  - "brace-expansion@5.0.8"
   - "sigstore@4.1.1"
 nodeLinker: hoisted
 overrides:
@@ -21,8 +22,7 @@ overrides:
   "@grpc/grpc-js@>=1.12.0 <1.12.7": "^1.12.7"
   "@protobufjs/utf8@<1.1.1": "^1.1.1"
   "@sigstore/core@<=3.2.0": "^3.2.1"
-  "brace-expansion@>=2.0.0 <2.1.2": "^2.1.2"
-  "brace-expansion@>=3.0.0 <5.0.7": "^5.0.7"
+  "brace-expansion@>=2.0.0 <5.0.8": "^5.0.8"
   "cross-spawn@<7.0.5": "^7.0.5"
   "diff@>=4.0.0 <4.0.4": "^4.0.4"
   "glob@<10.5.0": "^10.5.0"
@@ -42,7 +42,7 @@ overrides:
   "protobufjs-cli@<1.2.1": "^1.2.1"
   "protobufjs-cli@<=1.3.2": "^1.3.3"
   "sigstore@<=4.1.0": "^4.1.1"
-  "tar@>=7.0.0 <7.5.19": "^7.5.19"
+  "tar@>=7.0.0 <7.5.21": "^7.5.21"
   "tmp@<0.2.6": "^0.2.6"
   "underscore@<1.13.8": "^1.13.8"
 preferFrozenLockfile: true


### PR DESCRIPTION
## Summary

Clears the remaining moderate-or-higher pnpm advisories after the July remediation merge. All installed `brace-expansion` paths now resolve to `5.0.8`, and Pulumi's `tar` paths resolve to `7.5.21`.

The `brace-expansion@5.0.8` release-age exception is intentionally exact because the security patch had not yet cleared the repository's seven-day maturity gate.

## Validation

- `pnpm install --no-frozen-lockfile`
- Clean `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level moderate` — zero vulnerabilities
- `pnpm run build`
- `pnpm run lint:check`
- CodeRabbit committed review — no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version constraints across the workspace.
  * No changes to user-facing features or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->