### PR TITLE
fix(deps): remediate pacote advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   markdown-it@<=14.1.1: ^14.2.0
   minimatch@<9.0.7: ^9.0.7
   node-forge@<1.4.0: ^1.4.0
+  pacote@<21.5.1: ^21.5.1
   picomatch@<3.0.2: ^3.0.2
   tinyglobby@0.2.15>picomatch@>=4.0.0: ^3.0.2
   protobufjs@>=7.0.0 <7.6.5: ^7.6.5
@@ -1372,8 +1373,8 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  pacote@21.5.0:
-    resolution: {integrity: sha512-VtZ0SB8mb5Tzw3dXDfVAIjhyVKUHZkS/ZH9/5mpKenwC9sFOXNI0JI7kEF7IMkwOnsWMFrvAZHzx1T5fmrp9FQ==}
+  pacote@21.5.1:
+    resolution: {integrity: sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==}
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
@@ -1966,7 +1967,7 @@ snapshots:
       npm-package-arg: 13.0.2
       npm-pick-manifest: 11.0.3
       npm-registry-fetch: 19.1.1
-      pacote: 21.5.0
+      pacote: 21.5.1
       parse-conflict-json: 5.0.1
       proc-log: 6.1.0
       proggy: 4.0.0
@@ -2021,7 +2022,7 @@ snapshots:
     dependencies:
       cacache: 20.0.4
       json-parse-even-better-errors: 5.0.0
-      pacote: 21.5.0
+      pacote: 21.5.1
       proc-log: 6.1.0
       semver: 7.6.3
     transitivePeerDependencies:
@@ -3114,7 +3115,7 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  pacote@21.5.0:
+  pacote@21.5.1:
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@npmcli/git': 7.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,7 @@ overrides:
   "markdown-it@<=14.1.1": "^14.2.0"
   "minimatch@<9.0.7": "^9.0.7"
   "node-forge@<1.4.0": "^1.4.0"
+  "pacote@<21.5.1": "^21.5.1"
   "picomatch@<3.0.2": "^3.0.2"
   "tinyglobby@0.2.15>picomatch@>=4.0.0": "^3.0.2"
   "protobufjs@>=7.0.0 <7.6.5": "^7.6.5"


### PR DESCRIPTION
## Summary
- add a range-scoped override for vulnerable `pacote` releases below 21.5.1
- regenerate the pnpm lockfile so Pulumi/Arborist resolves `pacote@21.5.1`
- preserve the existing 7-day minimum release age without adding an exception

## Security assessment
- Fixes GHSA-w4pp-8pjf-rmxw (high severity DoS in `pacote` `addGitSha`)
- The affected paths are development-only through `@pulumi/gcp` / `@pulumi/pulumi` and are not included in the shipped API runtime graph
- The deployed API does not expose this build/deployment-tooling code path to external attackers

## Validation
- `pnpm install --no-frozen-lockfile`
- clean generated-state removal followed by `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level moderate` — no known vulnerabilities
- `pnpm why pacote` — one resolved version, `21.5.1`
- `pnpm run lint:check`
- `pnpm run build`
- pnpm 11 removed build-policy keys absent
- exact `allowBuilds` approvals verified in `pnpm-lock.yaml`
- `git diff --check`

Generated by the scheduled pnpm security remediation controller. This PR is intentionally draft and must not be merged automatically.
